### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Since Pollfish addresses the market research marketplace, Pollfish surveys can b
 ## Prerequisites
 
 *	iOS 6+ 
-*	XCode 5+
+*	Xcode 5+
 
 ## Quick Quide
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
